### PR TITLE
fix: Fixed the name of molecular_cell_biology_2 quiz

### DIFF
--- a/docs/mandatory/molecular_cell_biology_2/index.md
+++ b/docs/mandatory/molecular_cell_biology_2/index.md
@@ -123,7 +123,7 @@
                     <td><a href="./preview/2024_to_2025/quiz">查看</a></td>
                 </tr>
                 <tr>
-                    <td>2025-2026秋冬 小测</td>
+                    <td>2025-2026秋冬 小测（未更完）</td>
                     <td>历年卷</td>
                     <td>无</td>
                     <td><a href="./preview/2025_to_2026/quiz">查看</a></td>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,7 +139,7 @@ nav:
           - 2024-2025 期末测试: mandatory/medical_life_fundamentals/preview/2024_to_2025/final_exam.md
         - 细胞与生物分子Ⅱ:
           - 2024-2025 小测: mandatory/molecular_cell_biology_2/preview/2024_to_2025/quiz.md
-          - 2024-2025 小测: mandatory/molecular_cell_biology_2/preview/2025_to_2026/quiz.md
+          - 2025-2026 小测: mandatory/molecular_cell_biology_2/preview/2025_to_2026/quiz.md
           - 2024-2025 期末测试: mandatory/molecular_cell_biology_2/preview/2024_to_2025/final_exam.md
         - 遗传与发育Ⅱ:
           - 2023-2024 期末测试: mandatory/genetics_and_developmental_biology_2/preview/2023_to_2024/final_exam.md


### PR DESCRIPTION
- 给25-26细生二小测加了个“未更完”
- 25-26细生二小测在 nav 里误写为 2024-2025，已更正